### PR TITLE
Restructure rabbitmq config.

### DIFF
--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -1,5 +1,6 @@
-defaults: &defaults
-  host: localhost
+connection: &connection
+  hosts:
+    - localhost
   port: 5672
   vhost: /
   user: content_register
@@ -7,12 +8,14 @@ defaults: &defaults
   recover_from_connection_close: true
 
 development:
-  <<: *defaults
+  connection:
+    <<: *connection
   exchange: published_documents
   queue: content_register
 
 test:
-  <<: *defaults
-  user: content_register_test
+  connection:
+    <<: *connection
+    user: content_register_test
   exchange: content_register_published_documents_test_exchange
   queue: content_register_test

--- a/lib/message_queue_consumer.rb
+++ b/lib/message_queue_consumer.rb
@@ -10,7 +10,7 @@ class MessageQueueConsumer
 
   def initialize(config)
     @config = config.with_indifferent_access
-    connection = Bunny.new(@config)
+    connection = Bunny.new(@config[:connection].symbolize_keys)
     connection.start
     consumer_config = {
       :queue => @config.fetch(:queue),

--- a/spec/lib/message_queue_consumer_spec.rb
+++ b/spec/lib/message_queue_consumer_spec.rb
@@ -15,12 +15,14 @@ describe MessageQueueConsumer do
 
   describe "constructing an instance" do
     let(:config) {{
-      "hosts" => ["rabbitmq1.example.com", "rabbitmq2.example.com"],
-      "port" => 5672,
-      "vhost" => "/",
-      "user" => "a_user",
-      "pass" => "super secret",
-      "recover_from_connection_close" => true,
+      "connection" => {
+        "hosts" => ["rabbitmq1.example.com", "rabbitmq2.example.com"],
+        "port" => 5672,
+        "vhost" => "/",
+        "user" => "a_user",
+        "pass" => "super secret",
+        "recover_from_connection_close" => true,
+      },
       "queue" => "content_register",
       "exchange" => "published_documents",
     }}
@@ -30,7 +32,8 @@ describe MessageQueueConsumer do
     end
 
     it "connects to rabbitmq" do
-      expect(Bunny).to receive(:new).with(config).and_return(rabbitmq_connecton)
+      expected_options = config["connection"].symbolize_keys # Bunny requires the keys to be symbols
+      expect(Bunny).to receive(:new).with(expected_options).and_return(rabbitmq_connecton)
       expect(rabbitmq_connecton).to receive(:start)
 
       MessageQueueConsumer.new(config)

--- a/spec/support/message_queue_helpers.rb
+++ b/spec/support/message_queue_helpers.rb
@@ -22,7 +22,7 @@ module MessageQueueHelpers
     end
 
     def connection
-      @connection ||= Bunny.new(config).start
+      @connection ||= Bunny.new(config[:connection].symbolize_keys).start
     end
 
     def config


### PR DESCRIPTION
This seperates the connection config from other bits (exchange/queue
etc).  All the Bunny options are now under a separate `connection` key,
so they can be passed in directly without passing in extra options.

/cc @rboulton 
