### PR TITLE
Handle signals in consumer rake task.

### DIFF
--- a/lib/tasks/message_queue.rake
+++ b/lib/tasks/message_queue.rake
@@ -7,6 +7,10 @@ namespace :message_queue do
     # Note: this output is used in the test helpers to detect when this has started.
     puts "Starting message consumer"
     $stdout.flush
-    MessageQueueConsumer.run
+    begin
+      MessageQueueConsumer.run
+    rescue SignalException => e
+      puts "Received #{e}: exiting..."
+    end
   end
 end


### PR DESCRIPTION
When upstart stops the worker, it sends a `SIGTERM` to the process.  This
is manifested in ruby as a `SignalException`.  Unless handled, this
exception bubbles all the way up, and it intercepted by the airbrake
handler, resulting in noise in Errbit.

Handling this exception in the rake task prevents these spurious
exception reports in Errbit every time the workers are restarted.
