### PR TITLE
Ignore heartbeat messages

### DIFF
--- a/spec/lib/message_queue_consumer_heartbeat_processor_spec.rb
+++ b/spec/lib/message_queue_consumer_heartbeat_processor_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+require 'message_queue_consumer'
+
+describe MessageQueueConsumer::HeartbeatMiddlewareProcessor do
+  let(:heartbeat_headers) { instance_double("Bunny::MessageProperties", :content_type => "application/x-heartbeat") }
+  let(:heartbeat_message) { instance_double("RabbitmqConsumer::Message", :headers => heartbeat_headers, :ack => nil) }
+  let(:standard_headers) { instance_double("Bunny::MessageProperties", :content_type => nil) }
+  let(:standard_message) { instance_double("RabbitmqConsumer::Message", :headers => standard_headers, :ack => nil) }
+
+  let(:processor) { instance_double("MessageQueueConsumer::Processor") }
+
+  subject {
+    MessageQueueConsumer::HeartbeatMiddlewareProcessor.new(processor)
+  }
+
+  context "for a heartbeat message" do
+    it "doesn't call the next processor" do
+      expect(processor).not_to receive(:call)
+
+      subject.call(heartbeat_message)
+    end
+
+    it "acks the message" do
+      expect(heartbeat_message).to receive(:ack)
+
+      subject.call(heartbeat_message)
+    end
+  end
+
+  context "for a content message" do
+    it "calls the next processor" do
+      expect(processor).to receive(:call).with(standard_message)
+
+      subject.call(standard_message)
+    end
+
+    it "doesn't ack the message" do
+      expect(standard_message).not_to receive(:ack)
+      expect(processor).to receive(:call)
+
+      subject.call(standard_message)
+    end
+  end
+end

--- a/spec/lib/message_queue_consumer_spec.rb
+++ b/spec/lib/message_queue_consumer_spec.rb
@@ -45,8 +45,13 @@ describe MessageQueueConsumer do
         MessageQueueConsumer.new(config)
       end
 
-      it "passes an instance of MessageQueueConsumer::Processor" do
-        expect(RabbitmqConsumer).to receive(:new).with(anything, an_instance_of(MessageQueueConsumer::Processor), anything)
+      it "passes an instance of MessageQueueConsumer::HeartbeatMiddlewareProcessor" do
+        expect(RabbitmqConsumer).to receive(:new).with(anything, an_instance_of(MessageQueueConsumer::HeartbeatMiddlewareProcessor), anything)
+        MessageQueueConsumer.new(config)
+      end
+
+      it "passes an instance of MessageQueueConsumer::Processor to the HeartbeatMiddlewareProcessor" do
+        expect(MessageQueueConsumer::HeartbeatMiddlewareProcessor).to receive(:new).with(an_instance_of(MessageQueueConsumer::Processor))
         MessageQueueConsumer.new(config)
       end
 


### PR DESCRIPTION
Shortly, we will start emitting regular heartbeat messages to the
published_documents exchange.  These allow monitoring of the consumers
of queues bound to the exchange, by checking that the last heartbeat was
received recently.  Heartbeat messages can be identified by their
content type header, which is set to application/x-heartbeat.

This commit introduces a HeartbeatMiddlewareProcessor, which takes
another processor as an argument to its construtor, and passes all
non-heartbeat messages received on to that processor.

Heartbeat messages are ignored (other than calling "ack" on them).  This
could be changed in future to record the time of the latest heartbeat,
for monitoring purposes.
