### PR TITLE
Extract real format from placeholder_ prefixed variant

### DIFF
--- a/lib/message_queue_consumer.rb
+++ b/lib/message_queue_consumer.rb
@@ -49,6 +49,8 @@ class MessageQueueConsumer
         entry = Entry.find_or_initialize_by(:content_id => content_id)
         if message.body_data["format"] == "placeholder" && entry.format.present?
           entry.update_attributes!(message.body_data.slice("title", "base_path"))
+        elsif message.body_data["format"] =~ /\Aplaceholder_(.*)\z/
+          entry.update_attributes!(message.body_data.slice("title", "base_path").merge(:format => $1))
         else
           entry.update_attributes!(message.body_data.slice("title", "format", "base_path"))
         end

--- a/spec/integration/consuming_message_queue_spec.rb
+++ b/spec/integration/consuming_message_queue_spec.rb
@@ -73,4 +73,33 @@ describe "Consuming messages from the publishing-api message queue", :message_qu
       expect(entry.format).to eq("something")
     end
   end
+
+  describe "extracting the real format from a format of the form 'placeholder_foo'" do
+    it "creates an item with the real format" do
+      put_message_on_queue(message_data.merge("format" => "placeholder_answer"))
+
+      eventually do
+        expect(Entry.count).to eq(1)
+        e = Entry.find_by!(:content_id => message_data["content_id"])
+        expect(e).to be
+        expect(e.format).to eq("answer")
+      end
+    end
+
+    it "updates an item with the real format" do
+      entry = create(:entry,
+        :content_id => message_data["content_id"],
+        :title => "Old VAT rates",
+        :format => 'old-article',
+        :base_path => '/old-vat-rates',
+      )
+
+      put_message_on_queue(message_data.merge("format" => "placeholder_answer"))
+
+      eventually do
+        entry.reload
+        expect(entry.format).to eq("answer")
+      end
+    end
+  end
 end

--- a/spec/lib/message_queue_consumer_processor_spec.rb
+++ b/spec/lib/message_queue_consumer_processor_spec.rb
@@ -89,6 +89,33 @@ describe MessageQueueConsumer::Processor do
         expect(entry.format).to eq("article")
       end
     end
+
+    describe "placeholder format prefix special case" do
+      let(:message_data) { base_message_data.merge("format" => "placeholder_answer") }
+
+      it "creates an entry with a format of 'answer'" do
+        expect {
+          subject.call(message)
+        }.to change(Entry, :count).by(1)
+
+        entry = Entry.find_by(:content_id => message_data["content_id"])
+        expect(entry).to be
+        expect(entry.format).to eq("answer")
+      end
+
+      it "replaces an existing format with 'answer'" do
+        entry = create(:entry,
+          :content_id => message_data["content_id"],
+          :title => "Old VAT rates",
+          :format => 'article',
+        )
+
+        subject.call(message)
+
+        entry.reload
+        expect(entry.format).to eq("answer")
+      end
+    end
   end
 
   context "for an item without a content Id" do


### PR DESCRIPTION
An upcoming PR on content-store will allow it to support formats with a prefix of 'placeholder_' and not register routes for them.  This PR allows content-register to extract the real format from this prefixed variant.
