### PR TITLE
Remove Rails' default string column limit.

### DIFF
--- a/config/initializers/remove_default_column_limit.rb
+++ b/config/initializers/remove_default_column_limit.rb
@@ -1,0 +1,16 @@
+require 'active_record/connection_adapters/postgresql_adapter'
+
+# The Postgresql adapter has a default limit on string columns of 255 chars.  This causes
+# the column to be defined as 'character varying(255)' in the database.  It's also not possible
+# to override this default by setting limit to nil because the default is applied whenever the
+# given option is falsey[1]. This default has been removed in master[2] and will likely be included
+# in Rails 4.2. This override should therefore be removed when Rails is upgraded beyond that.
+#
+# [1] https://github.com/rails/rails/blob/v4.1.4/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb#L702
+# [2] https://github.com/rails/rails/pull/14579
+#
+if ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:string][:limit] == 255
+  ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:string].delete(:limit)
+else
+  raise "Default string limit for postgres is not set to 255.  Review monkey-patch in #{__FILE__}."
+end

--- a/db/migrate/20141126132957_fix_column_limits.rb
+++ b/db/migrate/20141126132957_fix_column_limits.rb
@@ -1,0 +1,13 @@
+class FixColumnLimits < ActiveRecord::Migration
+  def up
+    # This doesn't change anything at Rails' level, but it causes the change in
+    # config/initializers/remove_default_column_limit.rb to take effect.
+    change_column :entries, :content_id, :string
+    change_column :entries, :title, :string
+    change_column :entries, :format, :string
+    change_column :entries, :base_path, :string
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141030105134) do
+ActiveRecord::Schema.define(version: 20141126132957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -12,6 +12,17 @@ describe Entry do
     it { should validate_presence_of(:format) }
   end
 
+  it "supports fields longer than 255 chars" do
+    entry = build(:entry)
+    entry.title = "x" * 300
+    entry.base_path = "/" + "x" * 300
+    entry.format = "f" * 300
+
+    expect {
+      entry.save!
+    }.not_to raise_error
+  end
+
   context "#as_json" do
     let(:entry_attributes) { attributes_for(:entry) }
     let(:entry_json) { create(:entry, entry_attributes).as_json }


### PR DESCRIPTION
This is unhelpful, and unnecessary. See comment in the initializer for
more details.
