### PR TITLE
Ignore non-english content items on message queue

### DIFF
--- a/lib/message_queue_consumer.rb
+++ b/lib/message_queue_consumer.rb
@@ -45,7 +45,8 @@ class MessageQueueConsumer
 
     def call(message)
       content_id = message.body_data["content_id"]
-      if content_id.present?
+      # Ignore non-english items until a more nuanced approach can be created.
+      if content_id.present? && message.body_data["locale"] == "en"
         entry = Entry.find_or_initialize_by(:content_id => content_id)
         if message.body_data["format"] == "placeholder" && entry.format.present?
           entry.update_attributes!(message.body_data.slice("title", "base_path"))

--- a/spec/integration/consuming_message_queue_spec.rb
+++ b/spec/integration/consuming_message_queue_spec.rb
@@ -11,6 +11,7 @@ describe "Consuming messages from the publishing-api message queue", :message_qu
       "title" => "VAT rates",
       "description" => "Current VAT rates",
       "format" => "answer",
+      "locale" => "en",
       "need_ids" => ["100123", "100124"],
       "public_updated_at" => "2014-05-14T13:00:06Z",
       "updated_at" => "2014-05-14T13:05:06Z",

--- a/spec/lib/message_queue_consumer_processor_spec.rb
+++ b/spec/lib/message_queue_consumer_processor_spec.rb
@@ -10,6 +10,7 @@ describe MessageQueueConsumer::Processor do
       "title" => "VAT rates",
       "description" => "Current VAT rates",
       "format" => "answer",
+      "locale" => "en",
       "need_ids" => ["100123", "100124"],
       "public_updated_at" => "2014-05-14T13:00:06Z",
       "updated_at" => "2014-05-14T13:05:06Z",
@@ -61,6 +62,22 @@ describe MessageQueueConsumer::Processor do
       expect(message).to receive(:ack)
 
       subject.call(message)
+    end
+
+    describe "handling non-english content items" do
+      let(:message_data) { base_message_data.merge("locale" => "fr") }
+
+      it "does not create an Entry" do
+        expect {
+          subject.call(message)
+        }.not_to change(Entry, :count)
+      end
+
+      it "acks the message" do
+        expect(message).to receive(:ack)
+
+        subject.call(message)
+      end
     end
 
     describe "placeholder format special case" do


### PR DESCRIPTION
Until a more nuanced approach can be built we don't want item titles etc
being overwritten with their non-english variants.
