### PR TITLE
Retry messages on db uniqueness validation errors.

### DIFF
--- a/lib/message_queue_consumer.rb
+++ b/lib/message_queue_consumer.rb
@@ -57,6 +57,8 @@ class MessageQueueConsumer
         end
       end
       message.ack
+    rescue PG::UniqueViolation
+      message.retry
     end
   end
 end

--- a/spec/lib/message_queue_consumer_processor_spec.rb
+++ b/spec/lib/message_queue_consumer_processor_spec.rb
@@ -64,6 +64,13 @@ describe MessageQueueConsumer::Processor do
       subject.call(message)
     end
 
+    it "it retries the message on db uniqneness errors" do
+      allow_any_instance_of(Entry).to receive(:update_attributes!).and_raise(PG::UniqueViolation)
+      expect(message).to receive(:retry)
+
+      subject.call(message)
+    end
+
     describe "handling non-english content items" do
       let(:message_data) { base_message_data.merge("locale" => "fr") }
 


### PR DESCRIPTION
These will occur if two consumers try to create the same item
simultaneuosly (due to multiple messages for the same content_id coming
through very close together).  Retrying the message will result in it
becoming an update next time it's processed.
