### PR TITLE
Store and expose "links" of entries

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -5,7 +5,7 @@ class EntriesController < ApplicationController
   end
 
   def update
-    entry = Entry.find_or_initialize_by(content_id: params[:content_id])
+    entry = Entry.find_or_initialize_by(content_id: params[:id])
     status = if entry.update_attributes(request_data)
       (entry.created_at == entry.updated_at) ? :created : :ok
     else

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,7 +1,7 @@
 class Entry < ActiveRecord::Base
   serialize :links, Hash
 
-  PUBLIC_ATTRIBUTES = [:content_id, :title, :format, :base_path, :links]
+  PUBLIC_ATTRIBUTES = [:content_id, :title, :format, :base_path]
   UUID_REGEX = %r{
     [a-f\d]{8}
     -
@@ -22,6 +22,15 @@ class Entry < ActiveRecord::Base
   def as_json(options = {})
     super(options.merge(only: PUBLIC_ATTRIBUTES)).tap do |as_json_hash|
       as_json_hash['errors'] = errors.to_h.stringify_keys if errors.present?
+      as_json_hash['links'] = expanded_links
+    end
+  end
+
+private
+
+  def expanded_links
+    links.each_with_object({}) do |(key, content_ids), hash|
+      hash[key] = content_ids.map {|content_id| { 'content_id' => content_id} }
     end
   end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,4 +1,5 @@
 class Entry < ActiveRecord::Base
+  serialize :links, Hash
 
   PUBLIC_ATTRIBUTES = [:content_id, :title, :format, :base_path]
   UUID_REGEX = %r{

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,7 +1,7 @@
 class Entry < ActiveRecord::Base
   serialize :links, Hash
 
-  PUBLIC_ATTRIBUTES = [:content_id, :title, :format, :base_path]
+  PUBLIC_ATTRIBUTES = [:content_id, :title, :format, :base_path, :links]
   UUID_REGEX = %r{
     [a-f\d]{8}
     -

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   with_options :format => false do |r|
-    r.get '/entries' => 'entries#index'
-    r.put '/entry/:content_id' => 'entries#update', constraints: { content_id: Entry::UUID_REGEX }
+    r.get '/entries' => 'entries#index', as: :entries
+    r.put '/entry/:id' => 'entries#update', constraints: { id: Entry::UUID_REGEX }, as: :entry
 
     r.get '/healthcheck' => proc {|env| [200, {}, ["OK"]]}
   end

--- a/db/migrate/20150519134957_add_links_to_entries.rb
+++ b/db/migrate/20150519134957_add_links_to_entries.rb
@@ -1,0 +1,5 @@
+class AddLinksToEntries < ActiveRecord::Migration
+  def change
+    add_column :entries, :links, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141126132957) do
+ActiveRecord::Schema.define(version: 20150519134957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20141126132957) do
     t.string   "base_path"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "links"
   end
 
   add_index "entries", ["content_id"], name: "index_entries_on_content_id", unique: true, using: :btree

--- a/doc/input_example.json
+++ b/doc/input_example.json
@@ -2,5 +2,14 @@
 {
   "title": "Content Title",
   "format": "the format of this content",
-  "base_path": "/path-on-gov-uk"
+  "base_path": "/path-on-gov-uk",
+  "links": {
+    "things": [
+      "ea5126d0-590a-4c9d-bc9f-16b32b1fd261",
+      "a30d61aa-39e9-4a8a-9b7a-de4966a6797a"
+    ],
+    "more_things": [
+      "90a19160-9355-4d49-b61b-aa1851fe0a4c"
+    ]
+  }
 }

--- a/doc/output_example.json
+++ b/doc/output_example.json
@@ -3,12 +3,22 @@
     "content_id": "a5d86183-7252-4426-aad2-3f732f7f2581",
     "title": "Content Title",
     "format": "news-article",
-    "base_path": "/path-on-gov-uk"
+    "base_path": "/path-on-gov-uk",
+    "links": {
+      "things": [
+        { "content_id": "ea5126d0-590a-4c9d-bc9f-16b32b1fd261" },
+        { "content_id": "a30d61aa-39e9-4a8a-9b7a-de4966a6797a" }
+      ],
+      "more_things": [
+        { "content_id": "90a19160-9355-4d49-b61b-aa1851fe0a4c" }
+      ]
+    }
   },
   {
     "content_id": "000b4062-8eaa-45ea-ba3c-7c6683a8cbbe",
     "title": "Content Title 2",
     "format": "news-article",
-    "base_path": "/path-on-gov-uk-2"
+    "base_path": "/path-on-gov-uk-2",
+    "links": {}
   }
 ]

--- a/lib/message_queue_consumer.rb
+++ b/lib/message_queue_consumer.rb
@@ -53,7 +53,7 @@ class MessageQueueConsumer
         elsif message.body_data["format"] =~ /\Aplaceholder_(.*)\z/
           entry.update_attributes!(message.body_data.slice("title", "base_path").merge(:format => $1))
         else
-          entry.update_attributes!(message.body_data.slice("title", "format", "base_path"))
+          entry.update_attributes!(message.body_data.slice("title", "format", "base_path", "links"))
         end
       end
       message.ack

--- a/spec/factories/entry.rb
+++ b/spec/factories/entry.rb
@@ -4,5 +4,18 @@ FactoryGirl.define do
     sequence(:title) { |n| "Title of entry #{n}" }
     format 'news-article'
     base_path { "/#{title.parameterize}" }
+    links {
+      {
+        'things' => [
+          {
+            "title" => "A thing",
+            "base_path" => "/government/things/a-thing",
+            "api_url" => "https://www.gov.uk/api/content/government/things/a-thing",
+            "web_url" => "https://www.gov.uk/government/things/a-thing",
+            "locale" => "en"
+          }
+        ]
+      }
+    }
   end
 end

--- a/spec/factories/entry.rb
+++ b/spec/factories/entry.rb
@@ -4,18 +4,6 @@ FactoryGirl.define do
     sequence(:title) { |n| "Title of entry #{n}" }
     format 'news-article'
     base_path { "/#{title.parameterize}" }
-    links {
-      {
-        'things' => [
-          {
-            "title" => "A thing",
-            "base_path" => "/government/things/a-thing",
-            "api_url" => "https://www.gov.uk/api/content/government/things/a-thing",
-            "web_url" => "https://www.gov.uk/government/things/a-thing",
-            "locale" => "en"
-          }
-        ]
-      }
-    }
+    links { { "things" => [SecureRandom.uuid, SecureRandom.uuid] } }
   end
 end

--- a/spec/integration/consuming_message_queue_spec.rb
+++ b/spec/integration/consuming_message_queue_spec.rb
@@ -27,19 +27,7 @@ describe "Consuming messages from the publishing-api message queue", :message_qu
       ],
     }
   }
-  let(:links_hash) {
-    {
-        "things" => [
-          {
-            "title" => "A thing",
-            "base_path" => "/government/things/a-thing",
-            "api_url" => "https://www.gov.uk/api/content/government/things/a-thing",
-            "web_url" => "https://www.gov.uk/government/things/a-thing",
-            "locale" => "en"
-          }
-        ]
-      }
-  }
+  let(:links_hash) { { "things" => [SecureRandom.uuid, SecureRandom.uuid] } }
 
   it "creates an entry for the content item" do
     put_message_on_queue(message_data)

--- a/spec/integration/consuming_message_queue_spec.rb
+++ b/spec/integration/consuming_message_queue_spec.rb
@@ -21,10 +21,24 @@ describe "Consuming messages from the publishing-api message queue", :message_qu
       "details" => {
         "body" => "<p>Some body text</p>\n",
       },
+      "links" => links_hash,
       "routes" => [
         { "path" => "/vat-rates", "type" => 'exact' }
       ],
     }
+  }
+  let(:links_hash) {
+    {
+        "things" => [
+          {
+            "title" => "A thing",
+            "base_path" => "/government/things/a-thing",
+            "api_url" => "https://www.gov.uk/api/content/government/things/a-thing",
+            "web_url" => "https://www.gov.uk/government/things/a-thing",
+            "locale" => "en"
+          }
+        ]
+      }
   }
 
   it "creates an entry for the content item" do
@@ -32,11 +46,12 @@ describe "Consuming messages from the publishing-api message queue", :message_qu
 
     eventually do
       expect(Entry.count).to eq(1)
-      e = Entry.find_by!(:content_id => message_data["content_id"])
-      expect(e).to be
-      expect(e.title).to eq("VAT rates")
-      expect(e.format).to eq("answer")
-      expect(e.base_path).to eq("/vat-rates")
+      entry = Entry.find_by!(:content_id => message_data["content_id"])
+      expect(entry).to be
+      expect(entry.title).to eq("VAT rates")
+      expect(entry.format).to eq("answer")
+      expect(entry.base_path).to eq("/vat-rates")
+      expect(entry.links).to eq(links_hash)
     end
   end
 
@@ -46,6 +61,7 @@ describe "Consuming messages from the publishing-api message queue", :message_qu
       :title => "Old VAT rates",
       :format => 'old-article',
       :base_path => '/old-vat-rates',
+      :links => {},
     )
 
     put_message_on_queue(message_data)
@@ -55,6 +71,7 @@ describe "Consuming messages from the publishing-api message queue", :message_qu
       expect(entry.title).to eq("VAT rates")
       expect(entry.format).to eq("answer")
       expect(entry.base_path).to eq("/vat-rates")
+      expect(entry.links).to eq(links_hash)
     end
   end
 

--- a/spec/integration/submitting_entry_spec.rb
+++ b/spec/integration/submitting_entry_spec.rb
@@ -64,17 +64,7 @@ describe "Entry write API", :type => :request do
         "title" => "VAT rates",
         "format" => "answer",
         "base_path" => "/vat-rates",
-        "links" => {
-          "things" => [
-            {
-              "title" => "A thing",
-              "base_path" => "/government/things/a-thing",
-              "api_url" => "https://www.gov.uk/api/content/government/things/a-thing",
-              "web_url" => "https://www.gov.uk/government/things/a-thing",
-              "locale" => "en"
-            }
-          ]
-        }
+        "links" => { "things" => [SecureRandom.uuid, SecureRandom.uuid] },
       }
     }
     let(:updates) {

--- a/spec/integration/submitting_entry_spec.rb
+++ b/spec/integration/submitting_entry_spec.rb
@@ -10,7 +10,8 @@ describe "Entry write API", :type => :request do
         "content_id" => content_id,
         "title" => "VAT rates",
         "format" => "answer",
-        "base_path" => "/vat-rates"
+        "base_path" => "/vat-rates",
+        "links" => {},
       }
     }
 
@@ -23,7 +24,7 @@ describe "Entry write API", :type => :request do
       expect {
         put_json entry_path, data
       }.to change {
-        Entry.where(data).count
+        Entry.where(content_id: content_id).count
       }.from(0).to(1)
     end
 
@@ -62,7 +63,18 @@ describe "Entry write API", :type => :request do
         "content_id" => content_id,
         "title" => "VAT rates",
         "format" => "answer",
-        "base_path" => "/vat-rates"
+        "base_path" => "/vat-rates",
+        "links" => {
+          "things" => [
+            {
+              "title" => "A thing",
+              "base_path" => "/government/things/a-thing",
+              "api_url" => "https://www.gov.uk/api/content/government/things/a-thing",
+              "web_url" => "https://www.gov.uk/government/things/a-thing",
+              "locale" => "en"
+            }
+          ]
+        }
       }
     }
     let(:updates) {

--- a/spec/integration/submitting_entry_spec.rb
+++ b/spec/integration/submitting_entry_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe "Entry write API", :type => :request do
   let(:content_id) { SecureRandom.uuid }
-  let(:entry_path) { "/entry/#{content_id}" }
 
   context "creating a new entry with valid attributes" do
     let(:data) {
@@ -15,22 +14,21 @@ describe "Entry write API", :type => :request do
       }
     }
 
+    before do
+      put_json entry_path(content_id), data
+    end
+
     it "responds with a CREATED status" do
-      put_json entry_path, data
       expect(response).to have_http_status(:created)
     end
 
-    it "creates one entry" do
-      expect {
-        put_json entry_path, data
-      }.to change {
-        Entry.where(content_id: content_id).count
-      }.from(0).to(1)
+    it "creates an entry" do
+      expect(Entry.where(content_id: content_id).count).to eq(1)
     end
 
     it "responds with the created entry as JSON in the body" do
-      put_json entry_path, data
-      expect(parsed_response_body).to eq(data)
+      entry = Entry.find_by(content_id: content_id)
+      expect(parsed_response_body).to eq(entry.as_json)
     end
   end
 
@@ -44,29 +42,22 @@ describe "Entry write API", :type => :request do
       }
     }
 
+    before do
+      put_json entry_path(content_id), invalid_data
+    end
+
     it "returns Unprocessable Entity status" do
-      put_json entry_path, invalid_data
       expect(response).to have_http_status(:unprocessable_entity)
     end
 
     it "includes validation error messages in the response" do
-      put_json entry_path, invalid_data
-
       expect(parsed_response_body).to include(invalid_data)
       expect(parsed_response_body['errors']['title']).to include("can't be blank")
     end
   end
 
   context "updating an existing entry" do
-    let(:data) {
-      {
-        "content_id" => content_id,
-        "title" => "VAT rates",
-        "format" => "answer",
-        "base_path" => "/vat-rates",
-        "links" => { "things" => [SecureRandom.uuid, SecureRandom.uuid] },
-      }
-    }
+    let(:entry) { create(:entry) }
     let(:updates) {
       {
         "title" => "Revised VAT rates",
@@ -75,25 +66,21 @@ describe "Entry write API", :type => :request do
     }
 
     before do
-      put_json entry_path, data
+      put_json entry_path(entry.content_id), updates
     end
 
     it "responds with OK status" do
-      put_json entry_path, updates
       expect(response).to have_http_status(:ok)
     end
 
     it "updates the exisiting entry" do
-      put_json entry_path, updates
-
-      updated_entry = Entry.where(content_id: content_id).first
-      expect(updated_entry.title).to eq('Revised VAT rates')
-      expect(updated_entry.base_path).to eq('/revised-vat-rates')
+      entry.reload
+      expect(entry.title).to eq('Revised VAT rates')
+      expect(entry.base_path).to eq('/revised-vat-rates')
     end
 
     it "responds with the updated entry as JSON in the body" do
-      put_json entry_path, updates
-      expect(parsed_response_body).to eq(data.merge(updates))
+      expect(parsed_response_body).to eq(entry.reload.as_json)
     end
   end
 end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -24,14 +24,14 @@ describe Entry do
   end
 
   context "the links hash attribute" do
-      it "stores a serialized links hash" do
-        entry = build(:entry)
-        links = { "things" => [SecureRandom.uuid, SecureRandom.uuid] }
+    it "stores a serialized links hash" do
+      entry = build(:entry)
+      links = { "things" => [SecureRandom.uuid, SecureRandom.uuid] }
 
-        entry.links = links
-        entry.save!
-        expect(entry.reload.links).to eq(links)
-      end
+      entry.links = links
+      entry.save!
+      expect(entry.reload.links).to eq(links)
+    end
 
     it "validates links is a hash" do
       entry = build(:entry, links: [:an, :array])

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -23,13 +23,33 @@ describe Entry do
     }.not_to raise_error
   end
 
-  it "stores a serialized links hash" do
-    entry = build(:entry)
-    links = { "things" => [SecureRandom.uuid, SecureRandom.uuid] }
+  context "the links hash attribute" do
+      it "stores a serialized links hash" do
+        entry = build(:entry)
+        links = { "things" => [SecureRandom.uuid, SecureRandom.uuid] }
 
-    entry.links = links
-    entry.save!
-    expect(entry.reload.links).to eq(links)
+        entry.links = links
+        entry.save!
+        expect(entry.reload.links).to eq(links)
+      end
+
+    it "validates links is a hash" do
+      entry = build(:entry, links: [:an, :array])
+
+      expect(entry).not_to be_valid
+    end
+
+    it "validates links are specificed as an array" do
+      entry = build(:entry, links: { "things" => { 'content_id' => SecureRandom.uuid } })
+
+      expect(entry).not_to be_valid
+    end
+
+    it "validates links contain valid content ids" do
+      entry = build(:entry, links: { "things" => [SecureRandom.uuid, 'invalid-content-id'] })
+
+      expect(entry).not_to be_valid
+    end
   end
 
   context "#as_json" do

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -33,10 +33,11 @@ describe Entry do
   end
 
   context "#as_json" do
-    let(:entry) { create(:entry) }
+    let(:entry) { create(:entry, links: links) }
     let(:entry_json) { entry.as_json }
+    let(:links) { { "things" => [SecureRandom.uuid, SecureRandom.uuid] } }
 
-    [:base_path, :format, :title, :links, :content_id].each do |attribute|
+    [:base_path, :format, :title, :content_id].each do |attribute|
       it "includes the #{attribute} attribute" do
         expect(entry_json[attribute.to_s]).to eq(entry.public_send(attribute))
       end
@@ -46,6 +47,17 @@ describe Entry do
       it "excludes #{attribute} attribute" do
         expect(entry_json[attribute.to_s]).to be_nil
       end
+    end
+
+    it "expands linked items to a hash, including a key for 'content_id'" do
+      expanded_links = {
+        "things" => [
+          { "content_id" => links['things'][0] },
+          { "content_id" => links['things'][1] },
+        ]
+      }
+
+      expect(entry_json['links']).to eq(expanded_links)
     end
 
     it "includes errors hash when the object is invalid" do

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -25,17 +25,7 @@ describe Entry do
 
   it "stores a serialized links hash" do
     entry = build(:entry)
-    links = {
-      "things" => [
-        {
-          "title" => "A thing",
-          "base_path" => "/government/things/a-thing",
-          "api_url" => "https://www.gov.uk/api/content/government/things/a-thing",
-          "web_url" => "https://www.gov.uk/government/things/a-thing",
-          "locale" => "en"
-        }
-      ]
-    }
+    links = { "things" => [SecureRandom.uuid, SecureRandom.uuid] }
 
     entry.links = links
     entry.save!

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -43,12 +43,12 @@ describe Entry do
   end
 
   context "#as_json" do
-    let(:entry_attributes) { attributes_for(:entry) }
-    let(:entry_json) { create(:entry, entry_attributes).as_json }
+    let(:entry) { create(:entry) }
+    let(:entry_json) { entry.as_json }
 
-    Entry::PUBLIC_ATTRIBUTES.each do |attribute|
+    [:base_path, :format, :title, :links, :content_id].each do |attribute|
       it "includes the #{attribute} attribute" do
-        expect(entry_json[attribute.to_s]).to eq(entry_attributes[attribute])
+        expect(entry_json[attribute.to_s]).to eq(entry.public_send(attribute))
       end
     end
 

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -23,6 +23,25 @@ describe Entry do
     }.not_to raise_error
   end
 
+  it "stores a serialized links hash" do
+    entry = build(:entry)
+    links = {
+      "things" => [
+        {
+          "title" => "A thing",
+          "base_path" => "/government/things/a-thing",
+          "api_url" => "https://www.gov.uk/api/content/government/things/a-thing",
+          "web_url" => "https://www.gov.uk/government/things/a-thing",
+          "locale" => "en"
+        }
+      ]
+    }
+
+    entry.links = links
+    entry.save!
+    expect(entry.reload.links).to eq(links)
+  end
+
   context "#as_json" do
     let(:entry_attributes) { attributes_for(:entry) }
     let(:entry_json) { create(:entry, entry_attributes).as_json }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,12 +1,11 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'
-require 'spec_helper'
-
 # Necessary to ensure consistent test runs across environments.
 ENV['GOVUK_APP_DOMAIN'] = "test.gov.uk"
 
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'spec_helper'
 require 'shoulda/matchers'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/routing/entry_routing_spec.rb
+++ b/spec/routing/entry_routing_spec.rb
@@ -17,7 +17,7 @@ describe "routing of entry requests", :type => :routing do
       expect(put: "/entry/#{content_id}").to route_to({
         :controller => 'entries',
         :action => 'update',
-        :content_id => content_id,
+        :id => content_id,
       })
     end
 


### PR DESCRIPTION
To make it possible to infer relationships of entries in the content register, we want to expose "links". This updates the JSON representation of entries to include a partially-expanded set of links, currently only showing the `content_id`. Eventually, the expanded form will include details such as the title, format, base_path, etc, but that is a much larger piece of work that requires de-referencing of content_ids against other entries in content-register. For now, it is enough for us to partially expand the links, providing a future-proof data-structure that can be expanded later to include the other fields.

Trello: https://trello.com/c/dD6bkH5j/180-infer-programme-to-policy-relationship-when-tagging-editions
