### PR TITLE
Allow caching of entries

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,6 +1,9 @@
 class EntriesController < ApplicationController
   def index
     entries = Entry.where(format: params[:format]).order('created_at DESC')
+
+    expires_in 15.minutes, :public => true
+
     render json: entries
   end
 

--- a/spec/integration/fetching_entries_spec.rb
+++ b/spec/integration/fetching_entries_spec.rb
@@ -11,6 +11,7 @@ describe "Entry read API", :type => :request do
 
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to eq("application/json")
+      expect(response.cache_control).to eq({max_age: "900", public: true})
 
       expected_response_body = entries_for_answers.reverse.map { |entry| entry.as_json }
       expect(parsed_response_body).to eq(expected_response_body)


### PR DESCRIPTION
The entries list should be allowed to be cached for up to 15 minutes
before you have to refresh the data from the server. This will let our
apps do caching internally rather than hitting content-register every
time they try to look up the list of objects.
