### PR TITLE
Fix handling of database uniqueness violations.

### DIFF
--- a/lib/message_queue_consumer.rb
+++ b/lib/message_queue_consumer.rb
@@ -57,7 +57,7 @@ class MessageQueueConsumer
         end
       end
       message.ack
-    rescue PG::UniqueViolation
+    rescue ActiveRecord::RecordNotUnique
       message.retry
     end
   end

--- a/spec/lib/message_queue_consumer_processor_spec.rb
+++ b/spec/lib/message_queue_consumer_processor_spec.rb
@@ -65,7 +65,11 @@ describe MessageQueueConsumer::Processor do
     end
 
     it "it retries the message on db uniqneness errors" do
-      allow_any_instance_of(Entry).to receive(:update_attributes!).and_raise(PG::UniqueViolation)
+      err = ActiveRecord::RecordNotUnique.new(
+        "something",
+        PG::UniqueViolation.new('ERROR:  duplicate key value violates unique constraint "index_entries_on_content_id"')
+      )
+      allow_any_instance_of(Entry).to receive(:update_attributes!).and_raise(err)
       expect(message).to receive(:retry)
 
       subject.call(message)


### PR DESCRIPTION
When a database uniqueness constraint is violated, ActiveRecord wraps
the exception from the database driver in an
ActiveRecord::RecordNotUnique. This wasn't obvious because Airbrake
[unwraps this exception](https://github.com/airbrake/airbrake/blob/master/lib/airbrake.rb#L181-L187) before sending the error to Errbit [1].

This updates the rescue clause in the message queue processor to rescue
the correct exception class, and therefore handle the errors.

This should fix errors like https://errbit.preview.alphagov.co.uk/apps/5450da350da11540b20026c5/problems/559e31196578630700720600
