### PR TITLE
Add startup script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bundle install
+bundle exec rails s -p 3077


### PR DESCRIPTION
as per our other apps.

It's a convenience for starting the app in development if not using bowler/foreman.
