### PR TITLE
Strip non-UUID links on receipt.

### DIFF
--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -27,6 +27,21 @@ class Entry < ActiveRecord::Base
     end
   end
 
+  def links=(links_hash)
+    super unless links_hash.is_a?(Hash)
+
+    clean_hash = {}
+    links_hash.each do |link_type, array_of_content_ids|
+      if array_of_content_ids.is_a?(Array)
+        array_of_content_ids.select! { |id| id =~ /\A#{UUID_REGEX}\z/ }
+      end
+
+      clean_hash[link_type] = array_of_content_ids
+    end
+
+    super(clean_hash)
+  end
+
 private
 
   def expanded_links

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -45,10 +45,12 @@ describe Entry do
       expect(entry).not_to be_valid
     end
 
-    it "validates links contain valid content ids" do
-      entry = build(:entry, links: { "things" => [SecureRandom.uuid, 'invalid-content-id'] })
+    it "strips links that aren't valid content IDs" do
+      valid_content_id = SecureRandom.uuid
+      entry = build(:entry, links: { "things" => [valid_content_id, 'invalid-content-id'] })
 
-      expect(entry).not_to be_valid
+      expect(entry).to be_valid
+      expect(entry.links["things"]).to eq([valid_content_id])
     end
   end
 


### PR DESCRIPTION
We're sending some expanded links onto the queue
which breaches this app's validations.

Since these expanded links aren't used by the apps
which use content register, the simplest solution
is to strip them out on receipt.

This may need to be revisited when we begin sending
only expanded links onto the queue, but hopefully
this app will not exist by then.
